### PR TITLE
Iss#132 💾 & 💣 Handle closing records without data

### DIFF
--- a/src/components/RecordEditor.js
+++ b/src/components/RecordEditor.js
@@ -210,7 +210,8 @@ class RecordEditor extends React.Component {
 	}
 
 	handleClose() {
-		if (!Object.keys(this.state.record).includes('pid')) {
+		// checks if the record has a PID field on the record object. If not, the record is not saved.
+		if (!Object.keys(this.state.record).includes(this.props.config.id_field)) {
 			this.props.db.records.where('uid').equals(this.state.record.uid).delete()
 			this.saveAndExit()
 		} else {

--- a/src/components/RecordEditor.js
+++ b/src/components/RecordEditor.js
@@ -61,8 +61,6 @@ class RecordEditor extends React.Component {
 			this.props.codebook
 				.filter((d) => d.double_enter !== 'yes')
 				.forEach((d) => (state.record[d.name] = record[d.name]))
-
-			console.log(state.record)
 		} else {
 			state.record = record
 		}
@@ -476,7 +474,7 @@ class RecordEditor extends React.Component {
 							<button
 								className="button is-rounded save-and-exit"
 								onClick={() => {
-									this.saveAndExit()
+									this.handleClose()
 								}}
 							>
 								Close record

--- a/src/components/RecordEditor.js
+++ b/src/components/RecordEditor.js
@@ -211,6 +211,15 @@ class RecordEditor extends React.Component {
 		})
 	}
 
+	handleClose() {
+		if (!Object.keys(this.state.record).includes('pid')) {
+			this.props.db.records.where('uid').equals(this.state.record.uid).delete()
+			this.saveAndExit()
+		} else {
+			this.saveAndExit()
+		}
+	}
+
 	async finalizeDoubleEntry() {
 		await this.props.db.records
 			.where('uid')


### PR DESCRIPTION
Change made:
In the record editor, clicking the close button will only close & save the record if there is a `PID`. This is to prevent empty records from being crated and cluttering exports. 